### PR TITLE
feat: switch registry storage to DynamoDB via Dyntastic, add local fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,51 @@ python -m ipykernel install --user --name=tgov-scraper --display-name="TGOV Scra
 jupyter notebook
 ```
 
-### Prefect flows
+### Prefect workflows
+We use prefect to organize code into workflows of data tasks.
+
 See https://docs.prefect.io/get-started
 
 ```bash
 prefect server start                      # to start the persistent server
 
 python -m flows.translate_meetings        # to run a specific flow
+```
+
+#### Data "registry" for workflows
+The prefect workflows use a "registry" to track meetings and urls to their data artifacts.
+E.g., `get_new_meetings` task adds each meeting to the registry with a `video_url`, `transcribe_videos` transcribes the video and adds `transcription_url`, etc.
+
+```mermaid
+gitGraph
+    branch registry
+    checkout registry
+    commit id: " "
+
+    branch get_new_meetings
+    checkout get_new_meetings
+    commit id: "get_new_meetings()"
+    checkout registry
+    merge get_new_meetings id: "video_url"
+
+    branch transcribe_videos
+    checkout transcribe_videos
+    commit id: "transcribe_videos()"
+    checkout registry
+    merge transcribe_videos id: "transcription_url"
+
+    branch create_subtitled_video_pages
+    checkout create_subtitled_video_pages
+    commit id: "create_subtitled_video_pages()"
+    checkout registry
+    merge create_subtitled_video_pages id: "subtitled_video_url"
+
+    branch translate_transcriptions
+    checkout translate_transcriptions
+    commit id: "translate_transcriptions(es)"
+    commit id: "translate_transcriptions(mya)"
+    checkout registry
+    merge translate_transcriptions id: "translated_transcription_urls"
 ```
 
 ### Tests

--- a/db/create_tables.py
+++ b/db/create_tables.py
@@ -1,0 +1,9 @@
+from src.models.meeting import Meeting
+
+def create_tables():
+    print("Creating DynamoDB tables if they don't exist...")
+    Meeting.create_table(wait=True, billing_mode="PAY_PER_REQUEST")
+    print("All tables created!")
+
+if __name__ == "__main__":
+    create_tables()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ aiofiles = "^24.1.0"
 faster-whisper = "^1.1.1"
 prefect = "^3.3.0"
 boto3 = "^1.37.24"
+dyntastic = "^0.18.0"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/src/aws.py
+++ b/src/aws.py
@@ -3,8 +3,9 @@ import os
 import boto3
 from botocore.exceptions import ClientError, NoCredentialsError, PartialCredentialsError
 
+
 def is_aws_configured():
-    required_vars = ['AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY']
+    required_vars = ['AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY', 'AWS_DEFAULT_REGION']
     return all(var in os.environ for var in required_vars)
 
 
@@ -37,4 +38,3 @@ def upload_to_s3(file_path, bucket_name, s3_path):
     except (NoCredentialsError, PartialCredentialsError) as e:
         print(f"Failed to upload to S3: {str(e)}")
         return False
-

--- a/src/local_store.py
+++ b/src/local_store.py
@@ -1,0 +1,20 @@
+import json
+import os
+from typing import Sequence
+from src.models.meeting import Meeting
+
+LOCAL_STORE_PATH = "data/meetings.json"
+
+def read_meetings() -> Sequence[Meeting]:
+    if not os.path.exists(LOCAL_STORE_PATH):
+        return []
+
+    with open(LOCAL_STORE_PATH, 'r') as f:
+        data = json.load(f)
+        return [Meeting(**meeting) for meeting in data]
+
+def write_meetings(meetings: Sequence[Meeting]):
+    os.makedirs(os.path.dirname(LOCAL_STORE_PATH), exist_ok=True)
+    with open(LOCAL_STORE_PATH, 'w') as f:
+        json_data = [meeting.model_dump_json() for meeting in meetings]
+        json.dump(json_data, f)

--- a/src/models/meeting.py
+++ b/src/models/meeting.py
@@ -4,20 +4,24 @@ Pydantic models for meeting data
 
 from typing import Optional
 
+from dyntastic import Dyntastic
 from pydantic import BaseModel, Field, HttpUrl
 
 
-class Meeting(BaseModel):
+class Meeting(Dyntastic):
     """
     Model representing a government meeting
     """
 
+    __table_name__ = "tgov-meeting"
+    __hash_key__ = "clip_id"
+
+    clip_id: Optional[str] = Field(None, description="Granicus clip ID")
     meeting: str = Field(description="Name of the meeting")
     date: str = Field(description="Date and time of the meeting")
     duration: str = Field(description="Duration of the meeting")
     agenda: Optional[HttpUrl] = Field(None, description="URL to the meeting agenda")
     video: Optional[HttpUrl] = Field(None, description="URL to the meeting video")
-    clip_id: Optional[str] = Field(None, description="Granicus clip ID")
 
     def __str__(self) -> str:
         """String representation of the meeting"""

--- a/tasks/meetings.py
+++ b/tasks/meetings.py
@@ -10,7 +10,6 @@ async def get_new_meetings():
     # TODO: accept max_limit parameter
     tgov_meetings: Sequence[Meeting] = await get_tgov_meetings()
     print(f"Got {len(tgov_meetings)} tgov meetings.")
-    tgov_clip_ids = [tm.clip_id for tm in tgov_meetings]
     # print(f"tgov_clip_ids: {tgov_clip_ids}")
 
     registry_meetings: Sequence[Meeting] = get_registry_meetings()


### PR DESCRIPTION
- Add dyntastic
  - Update `Meeting` model to inherit from Dyntastic
  - Introduce `create_tables.py` for Dyntastic table creation
  - Refactor meeting registry read/write logic to use Dyntastic with DynamoDB
- Add `src/local_store.py` for local JSON fallback when AWS is not configured
- Clarify and expand README with Prefect workflows and registry diagram

<img width="799" alt="image" src="https://github.com/user-attachments/assets/ddb2337b-e37f-4454-b4eb-29344e20c74f" />
